### PR TITLE
Replace pkg_resources version lookup

### DIFF
--- a/src/mdatagen/__init__.py
+++ b/src/mdatagen/__init__.py
@@ -1,6 +1,7 @@
 try:
-    from pkg_resources import get_distribution, DistributionNotFound
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError, version
+
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass


### PR DESCRIPTION
Fixes #3.

## Summary
- replaces the `pkg_resources` version lookup in `mdatagen.__init__`
- uses `importlib.metadata.version()` and `PackageNotFoundError` from the Python standard library
- keeps the existing behavior when the package is imported from a source tree without installed metadata

## Validation
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `rg -n 'pkg_resources|get_distribution|DistributionNotFound|resource_filename|resource_stream|resource_dir' src setup.py setup.cfg README.md` returned no matches

Not run locally.